### PR TITLE
feat: add dataConverter support to Client constructor

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -204,6 +204,25 @@ export interface TemporalOptions extends LoggerConfig {
     isGlobal?: boolean;
     allowConnectionFailure?: boolean;
     /**
+     * Custom DataConverter for serializing and deserializing Temporal payloads.
+     * Use this to enable payload encryption (e.g. via a codec server) on the client side.
+     * The same DataConverter should be configured on the worker via `workerOptions.dataConverter`.
+     *
+     * @see https://docs.temporal.io/dataconversion
+     * @example
+     * ```typescript
+     * import { DataConverter } from '@temporalio/common';
+     *
+     * TemporalModule.registerAsync({
+     *   useFactory: (): TemporalOptions => ({
+     *     connection: { address: 'localhost:7233' },
+     *     dataConverter: myDataConverter,
+     *   }),
+     * });
+     * ```
+     */
+    dataConverter?: import('@temporalio/common').DataConverter;
+    /**
      * Enable NestJS shutdown hooks to properly handle SIGTERM/SIGINT signals.
      * When enabled, the module will register shutdown hooks to ensure graceful worker termination.
      * @default true
@@ -284,7 +303,7 @@ export interface WorkerCreateOptions {
     /**
      * Provide a custom DataConverter.
      */
-    dataConverter?: Record<string, unknown>;
+    dataConverter?: import('@temporalio/common').DataConverter;
 
     // Tuning and concurrency
     /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,7 +9,7 @@ export { Worker } from '@temporalio/worker';
 import { Type } from '@nestjs/common';
 import { ScheduleClient, ScheduleHandle } from '@temporalio/client';
 import { NativeConnection, Worker } from '@temporalio/worker';
-import { Duration, TypedSearchAttributes } from '@temporalio/common';
+import { DataConverter, Duration, TypedSearchAttributes } from '@temporalio/common';
 import { TLSConfig } from '@temporalio/common/lib/internal-non-workflow';
 
 /**
@@ -221,7 +221,7 @@ export interface TemporalOptions extends LoggerConfig {
      * });
      * ```
      */
-    dataConverter?: import('@temporalio/common').DataConverter;
+    dataConverter?: DataConverter;
     /**
      * Enable NestJS shutdown hooks to properly handle SIGTERM/SIGINT signals.
      * When enabled, the module will register shutdown hooks to ensure graceful worker termination.
@@ -303,7 +303,7 @@ export interface WorkerCreateOptions {
     /**
      * Provide a custom DataConverter.
      */
-    dataConverter?: import('@temporalio/common').DataConverter;
+    dataConverter?: DataConverter;
 
     // Tuning and concurrency
     /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -203,24 +203,7 @@ export interface TemporalOptions extends LoggerConfig {
     maxRestarts?: number;
     isGlobal?: boolean;
     allowConnectionFailure?: boolean;
-    /**
-     * Custom DataConverter for serializing and deserializing Temporal payloads.
-     * Use this to enable payload encryption (e.g. via a codec server) on the client side.
-     * The same DataConverter should be configured on the worker via `workerOptions.dataConverter`.
-     *
-     * @see https://docs.temporal.io/dataconversion
-     * @example
-     * ```typescript
-     * import { DataConverter } from '@temporalio/common';
-     *
-     * TemporalModule.registerAsync({
-     *   useFactory: (): TemporalOptions => ({
-     *     connection: { address: 'localhost:7233' },
-     *     dataConverter: myDataConverter,
-     *   }),
-     * });
-     * ```
-     */
+    /** Custom DataConverter for payload serialization/encryption. Also set on the worker via `workerOptions.dataConverter`. */
     dataConverter?: DataConverter;
     /**
      * Enable NestJS shutdown hooks to properly handle SIGTERM/SIGINT signals.

--- a/src/providers/temporal-connection.factory.ts
+++ b/src/providers/temporal-connection.factory.ts
@@ -179,6 +179,7 @@ export class TemporalConnectionFactory implements OnModuleDestroy {
             const client = new Client({
                 connection,
                 namespace: options.connection!.namespace || 'default',
+                ...(options.dataConverter && { dataConverter: options.dataConverter }),
             });
 
             // Cache the successful connection


### PR DESCRIPTION
## Summary

- Adds `dataConverter?: DataConverter` to `TemporalOptions` so callers can supply a custom `DataConverter` on the client side (e.g. for codec server payload encryption)
- Threads `dataConverter` into the `new Client({...})` constructor call in `TemporalConnectionFactory` — fully backward compatible (no-op when not provided)
- Tightens `WorkerCreateOptions.dataConverter` from the loose `Record<string, unknown>` to the proper `DataConverter` type from `@temporalio/common`

## Motivation

Without this change, configuring a custom `DataConverter` (required for Temporal's [codec server](https://docs.temporal.io/dataconversion#codec-server) encryption pattern) on the client was impossible — the field was silently ignored. The worker side already accepted `dataConverter` via `workerOptions`, but the client did not, making encrypted payload workflows non-functional.

## Test plan

- [ ] Verify existing behaviour unchanged when `dataConverter` is not provided
- [ ] Verify a custom `DataConverter` is passed through to the `Client` when configured in `TemporalOptions`